### PR TITLE
Email after channel becomes pending

### DIFF
--- a/www/api.py
+++ b/www/api.py
@@ -43,6 +43,7 @@ class NotifyHandler(RequestHandler):
             channel = Channel(target=target, source=source, outlet=target.get_default_outlet())
             channel.put()
             approval_notice = channel.get_approval_notice()
+            channel.send_activation_email()
             
         if channel:
             notice = Notification(channel=channel, text=strip_tags(self.request.get('text')), icon=source.source_icon)

--- a/www/models.py
+++ b/www/models.py
@@ -184,8 +184,17 @@ class Channel(db.Model):
         notice.icon = self.source.source_icon
         notice.sticky = 'true'
         return notice
-        
 
+    def send_activation_email(self):
+        if self.status == 'pending':
+            mail.send_mail(
+                sender="Notify.io <no-reply@notify-io.appspotmail.com>",
+                to="%s@gmail.com" % self.target.user,
+                subject="Approve a channel",
+                body="Hello,\n\nClick on this link to approve this channel:\n http://%s/sources" % WWW_HOST)
+        else:
+            raise Exception("Channel not pending")
+ 
 class Notification(db.Model):
     hash = db.StringProperty()
     channel = db.ReferenceProperty(Channel)


### PR DESCRIPTION
Hey!

This is the patch you told me to make, it works alright and i think its a step up and will be useful but, 2 things to notice:

1) If i have notifications directed to my email I will get 2 emails
2) I would like a direct link that can approve the channel, not only take me to a place where i can search for a button in the right.
3) The source list should contain the pending ones and show them on top.

I didn't know which ones of this to work in and didn't want to leave you hanging so, tell me what to do(and I will undertand if you don't pull this one because of the double email posibility).

Cheers
