### PR TITLE
Pass along URL for prowl 1.2

### DIFF
--- a/www/outlet_types.py
+++ b/www/outlet_types.py
@@ -55,6 +55,7 @@ class Prowl(BaseOutlet):
             'application': notice.source.source_name,
             'event': notice.title or '',
             'description': notice.text,
+            'url': notice.link or '',
 	    }
 		data = urllib.urlencode(utf8encode(data))
 		urlfetch.fetch("https://prowl.weks.net/publicapi/add/", method='POST', payload=data, headers={'Content-Type': 'application/x-www-form-urlencoded'})


### PR DESCRIPTION
simple change will allow prowl to receive urls passed along. would be really great if you could check and redeploy :)

notify.io rocks, thanks!
